### PR TITLE
Update activerecord dependency to 4.2.3

### DIFF
--- a/lib/models/ovirt_history.rb
+++ b/lib/models/ovirt_history.rb
@@ -16,7 +16,7 @@ module OvirtMetrics
     end
 
     def self.with_time_range(start_time = nil, end_time = nil)
-      return scoped if start_time.nil?
+      return all if start_time.nil?
       where(:history_datetime => (start_time..(end_time || Time.now.utc)))
     end
 

--- a/ovirt_metrics.gemspec
+++ b/ovirt_metrics.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "sqlite3"
   spec.add_development_dependency "coveralls"
 
-  spec.add_dependency "activerecord", "~> 3.2.0"
+  spec.add_dependency "activerecord", "~> 4.2.3"
 end


### PR DESCRIPTION
ManageIQ has moved on to rails 4.2.3.  Bumping the version of activerecord in ovirt_metrics keeps this consistent with the ManageIQ application (the main consumer of this library).

After running the specs locally, the only failure was due to the use of `scoped` in `OvirtHistory.with_time_range`.  Changing `scoped` to `all` fixes the test failure and managed to not introduce new test failures.  I *think* it's functionally equivalent based on the original context, but I'm not positive.

Awaiting other fallout of bumping the activerecord version.