### PR TITLE
Avoid collecting metrics for a VM that is not running

### DIFF
--- a/lib/ovirt_metrics.rb
+++ b/lib/ovirt_metrics.rb
@@ -9,6 +9,7 @@ Dir.glob(File.expand_path(File.join(File.dirname(__FILE__), "models", "*.rb"))) 
 module OvirtMetrics
   DEFAULT_HISTORY_DATABASE_NAME     = "ovirt_engine_history".freeze
   DEFAULT_HISTORY_DATABASE_NAME_3_0 = "rhevm_history".freeze
+  VM_NOT_RUNNING                    = 0
 
   def self.establish_connection(opts)
     self.connect(opts)
@@ -112,7 +113,7 @@ module OvirtMetrics
       values = {}
 
       column_definitions.each do |evm_col, info|
-        next if column_definitions == VM_COLUMN_DEFINITIONS && options[:metric].vm_status.to_i == 0
+        next if column_definitions == VM_COLUMN_DEFINITIONS && options[:metric].vm_status.to_i == VM_NOT_RUNNING
 
         counters_by_id[href][info[:ovirt_key]] ||= info[:counter]
         values[info[:ovirt_key]] = info[:ovirt_method].call(options)

--- a/lib/ovirt_metrics.rb
+++ b/lib/ovirt_metrics.rb
@@ -112,6 +112,8 @@ module OvirtMetrics
       values = {}
 
       column_definitions.each do |evm_col, info|
+        next if column_definitions == VM_COLUMN_DEFINITIONS && options[:metric].vm_status.to_i == 0
+
         counters_by_id[href][info[:ovirt_key]] ||= info[:counter]
         values[info[:ovirt_key]] = info[:ovirt_method].call(options)
       end


### PR DESCRIPTION
C&U:Computation of Daily Average of various metrics incorrect for RHEV VMs
https://bugzilla.redhat.com/show_bug.cgi?id=1061982

The version of the overt_metrics gem built into an appliance is outdated.

I still need to test this fix, using the latest version of the ovirt_metrics, which this PR is against.

I also need to add a spec test but wanted to start the feedback/review loops