### PR TITLE
Properly implement .disconnect

### DIFF
--- a/lib/ovirt_metrics.rb
+++ b/lib/ovirt_metrics.rb
@@ -43,7 +43,7 @@ module OvirtMetrics
   end
 
   def self.disconnect
-    OvirtHistory.connection.disconnect!
+    OvirtHistory.remove_connection
   end
 
   def self.vm_realtime(vm_id, start_time = nil, end_time = nil)


### PR DESCRIPTION
disconnect! disconnects the only the adapter connection; remove_connection
removes the connection for this class and will disconnect the correct
connection pool.

For BZ https://bugzilla.redhat.com/show_bug.cgi?id=1375253