### PR TITLE
Separate connection pools by specification name

### DIFF
--- a/lib/ovirt_metrics/configurator.rb
+++ b/lib/ovirt_metrics/configurator.rb
@@ -1,0 +1,24 @@
+module OvirtMetrics
+  class Configurator
+    def initialize
+      self.suppress_warnings = false
+      self.connection_specification_name = 'ovirt_metrics' if ActiveRecord::VERSION::MAJOR >= 5
+    end
+
+    attr_accessor :suppress_warnings
+
+    attr_reader :connection_specification_name
+
+    def connection_specification_name=(value)
+      if ActiveRecord::VERSION::MAJOR < 5
+        OvirtMetrics.warn "WARNING: ovirt_metric's " \
+          "connection_specification_name option is only available with " \
+          "Active Record 5 or newer. The main application pool " \
+          "('primary') will be used by default until you connect to a " \
+          "separate Ovirt database."
+      else
+        @connection_specification_name = value
+      end
+    end
+  end
+end

--- a/lib/ovirt_metrics/models/ovirt_history.rb
+++ b/lib/ovirt_metrics/models/ovirt_history.rb
@@ -1,7 +1,16 @@
 module OvirtMetrics
   class OvirtHistory < ActiveRecord::Base
+    attr_writer :connection_specification_name if ActiveRecord::VERSION::MAJOR < 5
+
     self.abstract_class = true
     self.pluralize_table_names = false
+
+    def self.connection_specification_name
+      if !defined?(@connection_specification_name) || @connection_specification_name.nil?
+        return self == OvirtHistory ? OvirtMetrics.config.connection_specification_name : superclass.connection_specification_name
+      end
+      @connection_specification_name
+    end
 
     def self.with_time_range(start_time = nil, end_time = nil)
       return all if start_time.nil?

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -77,6 +77,7 @@ RSpec.configure do |config|
 end
 
 require 'support/active_record'
+require 'ovirt_metrics'
 
 begin
   require 'coveralls'
@@ -84,4 +85,11 @@ begin
 rescue LoadError
 end
 
-require 'ovirt_metrics'
+OvirtMetrics.config do |c|
+  # Necessary because you currently cannot specify the
+  # connection name for ActiveRecord::Schema, which we use
+  # in tests to reset db schema for different RHEV versions.
+  c.connection_specification_name = 'primary' if ActiveRecord::VERSION::MAJOR >= 5
+end
+ActiveRecord::Base.establish_connection :adapter => "sqlite3", :database => ":memory:"
+

--- a/spec/support/active_record.rb
+++ b/spec/support/active_record.rb
@@ -1,7 +1,5 @@
 require 'active_record'
 
-ActiveRecord::Base.establish_connection adapter: "sqlite3", database: ":memory:"
-
 module ActiveModel::Validations
   # Extension to enhance `should have` on AR Model instances.  Calls
   # model.valid? in order to prepare the object's errors object.


### PR DESCRIPTION
Previously:

```
> require 'ovirt_metrics'
> OvirtMetrics.connected?  # => true, before we even do anything
```

I discovered that this is because all of the Ovirt models are actually
inheriting ActiveRecord::Base's connection pool (the primary application
pool), so in fact the gem's `connected?` API has been falsely going off
the normal application database, amongst other issues.

This change sets the Ovirt models to use their own connection pool
separate from the application and thus connect independently, as well as
a correct checking of the connection. Now you should be able to use this
API and connect/disconnect to your heart's content:

```
(connection info redacted)
[1] pry(main)> require 'ovirt_metrics'
=> true
[2] pry(main)> OvirtMetrics.connected?
=> false
[3] pry(main)> OvirtMetrics.connect(...)
=> #<ActiveRecord::ConnectionAdapters::ConnectionPool:0x007faa2df0b6b0
[4] pry(main)> OvirtMetrics.connected?
OvirtLegacyPostgreSQLAdapter#log_after_checkout, connection_pool: size: 5, connections: 1, in use: 0, waiting_in_queue: 0
=> true
[5] pry(main)> OvirtMetrics.disconnect
OvirtLegacyPostgreSQLAdapter#log_after_checkin, connection_pool: size: 5, connections: 1, in use: 0, waiting_in_queue: 0
=> {connection info redacted}
[6] pry(main)> OvirtMetrics.connected?
=> false
[7] pry(main)> OvirtMetrics.connect(...)
=> #<ActiveRecord::ConnectionAdapters::ConnectionPool:0x007faa2a7df920
[8] pry(main)> OvirtMetrics.connected?
OvirtLegacyPostgreSQLAdapter#log_after_checkout, connection_pool: size: 5, connections: 1, in use: 0, waiting_in_queue: 0
=> true
[9] pry(main)> OvirtMetrics.disconnect
OvirtLegacyPostgreSQLAdapter#log_after_checkin, connection_pool: size: 5, connections: 1, in use: 0, waiting_in_queue: 0
=> {connection info redacted}
[10] pry(main)> OvirtMetrics.connected?
=> false
```

Note that beyond connection info just not having been fed to
ovirt_metrics yet (responds false), other exceptions like PGErrors still
raise to the surface (as before)

Also note that this feature is *only* available for ActiveRecord 5+. It
is disabled and backwards compatible for all Rails versions. For those
older versions, the default application pool will be used as always.

Lastly, this commit also introduces a configurator object you can access in a
nice block in your application to configure things (currently,
suppressing warnings and setting a custom connection specification name
for ActiveRecord 5+)