### PR TITLE
Get the disks_ids in a way that would work for 3.6

### DIFF
--- a/lib/ovirt_metrics.rb
+++ b/lib/ovirt_metrics.rb
@@ -59,7 +59,8 @@ module OvirtMetrics
     host_realtime_metrics_to_hashes(metrics, nic_metrics)
   end
 
-  private
+  # The methods below this line are PRIVATE not meant to be used out of the scope
+  # of this class. TODO refactor to force privacy or remove this line.
 
   def self.query_host_realtime_metrics(host_id, start_time = nil, end_time = nil)
     HostSamplesHistory.where(:host_id => host_id).includes(:host_configuration).with_time_range(start_time, end_time)
@@ -82,8 +83,12 @@ module OvirtMetrics
   end
 
   def self.query_vm_disk_realtime_metrics(vm_id, start_time = nil, end_time = nil)
-    disk_ids = DisksVmMap.where(:vm_id => vm_id).collect(&:vm_disk_id)
+    disk_ids = vms_disk_ids_for(vm_id)
     VmDiskSamplesHistory.where(:vm_disk_id => disk_ids).with_time_range(start_time, end_time)
+  end
+
+  def self.vms_disk_ids_for(vm_id)
+    VmDeviceHistory.where(:vm_id => vm_id).disks.attached.pluck('DISTINCT device_id')
   end
 
   def self.query_vm_nic_realtime_metrics(vm_id, start_time = nil, end_time = nil)

--- a/lib/ovirt_metrics/models/vm_device_history.rb
+++ b/lib/ovirt_metrics/models/vm_device_history.rb
@@ -1,0 +1,10 @@
+module OvirtMetrics
+  class VmDeviceHistory < OvirtHistory
+    # have to rename the inheritance_column since this table has a column
+    # called "type"
+    self.inheritance_column = :_type_disabled
+
+    scope :disks,    -> { where(:type => "disk") }
+    scope :attached, -> { where(:delete_date => nil) }
+  end
+end

--- a/spec/ovirt_metrics_spec.rb
+++ b/spec/ovirt_metrics_spec.rb
@@ -1,6 +1,36 @@
 describe OvirtMetrics do
   shared_examples_for "OvirtMetrics" do |multiplication_required|
     let(:multiplication_required) { multiplication_required }
+    describe ".vms_disk_ids_for" do
+      before(:each) do
+        @vm1_id = 1
+        @device_id1 = "device1"
+        @device_id2 = "device2"
+        generic_params = {
+          :vm_id       => @vm1_id,
+          :device_id   => @device_id1,
+          :type        => "disk",
+          :address     => "address",
+          :create_date => 1.week.ago
+        }
+        OvirtMetrics::VmDeviceHistory.create(generic_params)
+        OvirtMetrics::VmDeviceHistory.create(generic_params.merge(:address => "duplicate_with_same_device_id"))
+        OvirtMetrics::VmDeviceHistory.create(generic_params.merge(:device_id => @device_id2))
+        OvirtMetrics::VmDeviceHistory.create(generic_params.merge(:vm_id => 2, :device_id => "disk_from_other_vm"))
+        OvirtMetrics::VmDeviceHistory.create(generic_params.merge(:type      => "nic",
+                                                                  :device_id => "device_of_non_disk_type"))
+        OvirtMetrics::VmDeviceHistory.create(generic_params.merge(:device_id   => "device_that_was_deleted",
+                                                                  :delete_date => 2.days.ago))
+      end
+
+      subject { described_class.vms_disk_ids_for(@vm1_id) }
+
+      it { is_expected.to match_array([@device_id1, @device_id2]) }
+      it { is_expected.not_to include("disk_from_other_vm") }
+      it { is_expected.not_to include("device_of_non_disk_type") }
+      it { is_expected.not_to include("device_that_was_deleted") }
+    end
+
     context ".vm_realtime" do
       it "when vm_id finds no matches" do
         expect(described_class.vm_realtime(42)).to eq([{}, {}])
@@ -55,11 +85,6 @@ describe OvirtMetrics do
       expect(described_class.send(method, id)).to eq([columns, rows])
     end
 
-  end
-
-  context "RHEV 3.0" do
-    before(:each) { load_rhev_30 }
-    it_should_behave_like "OvirtMetrics", true
   end
 
   context "RHEV 3.1" do


### PR DESCRIPTION
When doing query_vm_disk_realtime_metrics use vm_device_history instead
of disks_vm_map to get the disks ids since this table has the right data
in version 3.6 of Ovirt DWH and in version 4.0

https://bugzilla.redhat.com/show_bug.cgi?id=1373460