### PR TITLE
Fix getting nic_ids for VMs

### DIFF
--- a/lib/ovirt_metrics.rb
+++ b/lib/ovirt_metrics.rb
@@ -111,8 +111,12 @@ module OvirtMetrics
     VmDeviceHistory.where(:vm_id => vm_id).disks.attached.pluck('DISTINCT device_id')
   end
 
+  def self.vms_nic_ids_for(vm_id)
+    VmDeviceHistory.where(:vm_id => vm_id).nics.attached.pluck("DISTINCT device_id")
+  end
+
   def self.query_vm_nic_realtime_metrics(vm_id, start_time = nil, end_time = nil)
-    nic_ids = VmInterfaceConfiguration.where(:vm_id => vm_id).collect(&:vm_interface_id)
+    nic_ids = vms_nic_ids_for(vm_id)
     VmInterfaceSamplesHistory.where(:vm_interface_id => nic_ids).with_time_range(start_time, end_time)
   end
 

--- a/lib/ovirt_metrics/models/vm_device_history.rb
+++ b/lib/ovirt_metrics/models/vm_device_history.rb
@@ -5,6 +5,7 @@ module OvirtMetrics
     self.inheritance_column = :_type_disabled
 
     scope :disks,    -> { where(:type => "disk") }
+    scope :nics,     -> { where(:type => "interface") }
     scope :attached, -> { where(:delete_date => nil) }
   end
 end


### PR DESCRIPTION
Get the nic_ids for a VM based on the vm_device_history table.

https://bugzilla.redhat.com/show_bug.cgi?id=1404391