### PR TITLE
Fix doubled values in C&U

### DIFF
--- a/lib/ovirt_metrics/column_definitions.rb
+++ b/lib/ovirt_metrics/column_definitions.rb
@@ -21,7 +21,7 @@ module OvirtMetrics
         :counter_key           => "cpu_usagemhz_rate_average",
         :instance              => "",
         :capture_interval      => "20",
-        :precision             => 2,
+        :precision             => 1,
         :rollup                => "average",
         :unit_key              => "megahertz",
         :capture_interval_name => "realtime"
@@ -55,7 +55,7 @@ module OvirtMetrics
         :counter_key           => "disk_usage_rate_average",
         :instance              => "",
         :capture_interval      => "20",
-        :precision             => 2,
+        :precision             => 1,
         :rollup                => "average",
         :unit_key              => "kilobytespersecond",
         :capture_interval_name => "realtime"
@@ -69,7 +69,7 @@ module OvirtMetrics
         :counter_key           => "net_usage_rate_average",
         :instance              => "",
         :capture_interval      => "20",
-        :precision             => 2,
+        :precision             => 1,
         :rollup                => "average",
         :unit_key              => "kilobytespersecond",
         :capture_interval_name => "realtime"
@@ -89,7 +89,7 @@ module OvirtMetrics
         :counter_key           => "net_usage_rate_average",
         :instance              => "",
         :capture_interval      => "20",
-        :precision             => 2,
+        :precision             => 1,
         :rollup                => "average",
         :unit_key              => "kilobytespersecond",
         :capture_interval_name => "realtime"


### PR DESCRIPTION
The precision value in column defenition was set to 2 for several columns
which caused the data to be doubled in mangeiq here:
https://github.com/ManageIq/manageiq/blob/327a87d064cd45cee083a4c058b0f6f13524b161/app/models/metric/ci_mixin/processing.rb#L190

This fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1495133