### PR TITLE
Fix error in ActiveRecord Logging

### DIFF
--- a/lib/active_record/connection_adapters/ovirt_legacy_postgresql_adapter.rb
+++ b/lib/active_record/connection_adapters/ovirt_legacy_postgresql_adapter.rb
@@ -607,15 +607,14 @@ module ActiveRecord
         end
 
         def exec_no_cache(sql, name, binds)
-          type_casted_binds = binds.map { |attr| type_cast(attr.value_for_database) }
-          log(sql, name, binds) { @connection.async_exec(sql, type_casted_binds) }
+          type_casted_binds = type_casted_binds(binds)
+          log(sql, name, binds, type_casted_binds) { @connection.async_exec(sql, type_casted_binds) }
         end
 
         def exec_cache(sql, name, binds)
           stmt_key = prepare_statement(sql)
-          type_casted_binds = binds.map { |attr| type_cast(attr.value_for_database) }
-
-          log(sql, name, binds, stmt_key) do
+          type_casted_binds = type_casted_binds(binds)
+          log(sql, name, binds, type_casted_binds, stmt_key) do
             @connection.exec_prepared(stmt_key, type_casted_binds)
           end
         rescue ActiveRecord::StatementInvalid => e


### PR DESCRIPTION
Used to get an error when trying to query through the legacy_adapter due to changes
in active_record.

Applied a change from https://github.com/rails/rails/pull/28495/files/1696a0fc7f9c6910df8865e14df7d767af046ebf#diff-cc31fc1dd1e78db64638200f710b2f59
to the legacy adapter to fix the error.

This addresses: https://github.com/ManageIQ/ovirt_metrics/issues/24