### PR TITLE
Remove test and assignment of legacy adapter

### DIFF
--- a/lib/ovirt_metrics.rb
+++ b/lib/ovirt_metrics.rb
@@ -27,14 +27,7 @@ module OvirtMetrics
     opts            ||= {}
     opts[:port]     ||= 5432
     opts[:database] ||= DEFAULT_HISTORY_DATABASE_NAME
-    opts[:adapter]    = begin
-                          if ActiveRecord::VERSION::MAJOR > 4
-                            require "active_record/connection_adapters/ovirt_legacy_postgresql_adapter"
-                            'ovirt_legacy_postgresql'
-                          else
-                            'postgresql'
-                          end
-                        end
+    opts[:adapter]    = 'postgresql'
 
     # Don't allow accidental connections to localhost.  A blank host will
     # connect to localhost, so don't allow that at all.


### PR DESCRIPTION
The legacy adapter layer is causing connection endpoint validation
failure for newer postgresql versions.

This should solve:
https://bugzilla.redhat.com/show_bug.cgi?id=1373460