### PR TITLE
ConnectionAdapter with check_version overriding

### DIFF
--- a/lib/active_record/connection_adapters/ovirt_postgresql_adapter.rb
+++ b/lib/active_record/connection_adapters/ovirt_postgresql_adapter.rb
@@ -1,0 +1,30 @@
+module ActiveRecord
+  module ConnectionHandling # :nodoc:
+    def ovirt_postgresql_connection(config)
+      conn_params = config.symbolize_keys
+
+      conn_params.delete_if { |_, v| v.nil? }
+
+      conn_params[:user] = conn_params.delete(:username) if conn_params[:username]
+      conn_params[:dbname] = conn_params.delete(:database) if conn_params[:database]
+
+      valid_conn_param_keys = PG::Connection.conndefaults_hash.keys + [:requiressl]
+      conn_params.slice!(*valid_conn_param_keys)
+
+      ConnectionAdapters::OvirtPostgreSQLAdapter.new(nil, logger, conn_params, config)
+    end
+  end
+
+  module ConnectionAdapters
+    class OvirtPostgreSQLAdapter < PostgreSQLAdapter
+      ADAPTER_NAME = "OvirtPostgreSQL"
+
+      def check_version
+        msg = "The version of PostgreSQL (#{postgresql_version}) is too old (9.2+ required)"
+        if postgresql_version < 90200
+          raise msg
+        end
+      end
+    end
+  end
+end

--- a/lib/ovirt_metrics.rb
+++ b/lib/ovirt_metrics.rb
@@ -27,7 +27,10 @@ module OvirtMetrics
     opts            ||= {}
     opts[:port]     ||= 5432
     opts[:database] ||= DEFAULT_HISTORY_DATABASE_NAME
-    opts[:adapter]    = 'postgresql'
+    opts[:adapter] = begin
+                       require "active_record/connection_adapters/ovirt_postgresql_adapter"
+                       'ovirt_postgresql'
+                     end
 
     # Don't allow accidental connections to localhost.  A blank host will
     # connect to localhost, so don't allow that at all.


### PR DESCRIPTION
New OvirtPostgreSQLAdapter that extends the default one adding
a check_version method to override restrictions imposed by the
manageiq postgresql_required_versions initializer.
This modification, with the update of the initializer mentioned
above should solve:

https://bugzilla.redhat.com/show_bug.cgi?id=1734770

- [x] Depends on https://github.com/ManageIQ/manageiq/pull/19090