### PR TITLE
Pass in a connection when initializing postgresql connection adapter on Rails 6

### DIFF
--- a/lib/active_record/connection_adapters/ovirt_postgresql_adapter.rb
+++ b/lib/active_record/connection_adapters/ovirt_postgresql_adapter.rb
@@ -11,7 +11,8 @@ module ActiveRecord
       valid_conn_param_keys = PG::Connection.conndefaults_hash.keys + [:requiressl]
       conn_params.slice!(*valid_conn_param_keys)
 
-      ConnectionAdapters::OvirtPostgreSQLAdapter.new(nil, logger, conn_params, config)
+      conn = PG.connect(conn_params) if ActiveRecord::VERSION::MAJOR >= 6
+      ConnectionAdapters::OvirtPostgreSQLAdapter.new(conn, logger, conn_params, config)
     end
   end
 


### PR DESCRIPTION
On ActiveRecord 6.0+ the `ConnectionAdapters::PostgreSQLAdapter#initialize` expects to be passed in a valid postgres connection, where previous versions expected this to be `nil`.

On rails 5 the ` ConnectionAdapters::PostgreSQLAdapter` is initialized with a `nil` first argument [[ref]](https://github.com/rails/rails/blob/5-2-stable/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L48)
But on rails 6 it is expected to be passed in a valid connection [[ref]](https://github.com/rails/rails/blob/6-0-stable/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L46-L47)

Without a valid `@connection` already set, the [`configure_connection`](https://github.com/rails/rails/blob/6-0-stable/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L256) method fails while executing a query because it assumes `@connection` is already set.

Fixes https://github.com/ManageIQ/manageiq-providers-ovirt/issues/580