### PR TITLE
Allow rails 7 gems in gemspec

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,16 @@ jobs:
         rails-version:
         - '6.0'
         - '6.1'
+        include:
+        - ruby-version: '3.1'
+          rails-version: '6.1'
+        # rails 7 requires ruby 2.7+
+        - ruby-version: '2.7'
+          rails-version: '7.0'
+        - ruby-version: '3.0'
+          rails-version: '7.0'
+        - ruby-version: '3.1'
+          rails-version: '7.0'
     env:
       TEST_RAILS_VERSION: ${{ matrix.rails-version }}
       CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}

--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,14 @@ source 'https://rubygems.org'
 
 gemspec
 
-case ENV['TEST_RAILS_VERSION']
-when "6.0"
-  gem "activerecord", "~>6.0.4"
-when "6.1"
-  gem "activerecord", "~>6.1.4"
-end
+minimum_version =
+  case ENV['TEST_RAILS_VERSION']
+  when "6.0"
+    "~>6.0.4"
+  when "7.0"
+    "~>7.0.8"
+  else
+    "~>6.1.4"
+  end
+
+gem "activerecord", minimum_version

--- a/lib/ovirt_metrics/configurator.rb
+++ b/lib/ovirt_metrics/configurator.rb
@@ -10,15 +10,7 @@ module OvirtMetrics
     attr_reader :connection_specification_name
 
     def connection_specification_name=(value)
-      if ActiveRecord::VERSION::MAJOR < 5
-        OvirtMetrics.warn "WARNING: ovirt_metric's " \
-          "connection_specification_name option is only available with " \
-          "Active Record 5 or newer. The main application pool " \
-          "('primary') will be used by default until you connect to a " \
-          "separate Ovirt database."
-      else
-        @connection_specification_name = value
-      end
+      @connection_specification_name = value
     end
   end
 end

--- a/ovirt_metrics.gemspec
+++ b/ovirt_metrics.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.5.8"
 
-  spec.add_dependency "activerecord", ">=5.0", "<7.0"
+  spec.add_dependency "activerecord", ">=6.0"
   spec.add_dependency "pg"
 
   spec.add_development_dependency "bundler"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -88,7 +88,12 @@ OvirtMetrics.config do |c|
   # Necessary because you currently cannot specify the
   # connection name for ActiveRecord::Schema, which we use
   # in tests to reset db schema for different RHEV versions.
-  c.connection_specification_name = 'primary' if ActiveRecord::VERSION::MAJOR >= 5
+  case ActiveRecord::VERSION::MAJOR
+  when 7
+    c.connection_specification_name = 'ActiveRecord::Base'
+  else
+    c.connection_specification_name = 'primary'
+  end
 end
 ActiveRecord::Base.establish_connection :adapter => "sqlite3", :database => ":memory:"
 


### PR DESCRIPTION
Add rails 7 tests for ruby 2.7+, drop EOL rails 5

Fix rails 7 code to use `connection_specification_name` as `AR::Base` instead of `primary`