### PR TITLE
Fix issue where sqlite3 doesn't bundle properly with Rails 7 and below

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,3 +13,6 @@ minimum_version =
   end
 
 gem "activerecord", minimum_version
+
+# sqlite3 doesn't bundle properly with Rails 7.0 or less.
+gem "sqlite3", "< 2"


### PR DESCRIPTION
@agrare Please review.  This gets master back to green.  We had a similar problem in active_record-virtual_attributes.  I haven't had a chance to dig in as to what exactly is happening, but the error during bundling before this change is:

```
An error occurred while loading spec_helper. - Did you mean?
                    rspec ./spec/spec_helper.rb

Failure/Error: ActiveRecord::Base.establish_connection :adapter => "sqlite3", :database => ":memory:"

LoadError:
  Error loading the 'sqlite3' Active Record adapter. Missing a gem it depends on? can't activate sqlite3 (~> 1.4), already activated sqlite3-2.0.1-arm64-darwin. Make sure all dependencies are added to Gemfile.
# /Users/jfrey/.gem/ruby/3.1.4/gems/activerecord-6.1.7.7/lib/active_record/connection_adapters/sqlite3_adapter.rb:13:in `<top (required)>'
# /Users/jfrey/.gem/ruby/3.1.4/gems/activesupport-6.1.7.7/lib/active_support/dependencies.rb:332:in `block in require'
# /Users/jfrey/.gem/ruby/3.1.4/gems/activesupport-6.1.7.7/lib/active_support/dependencies.rb:299:in `load_dependency'
# /Users/jfrey/.gem/ruby/3.1.4/gems/activesupport-6.1.7.7/lib/active_support/dependencies.rb:332:in `require'
# /Users/jfrey/.gem/ruby/3.1.4/gems/activerecord-6.1.7.7/lib/active_record/connection_adapters/abstract/connection_pool.rb:1205:in `resolve_pool_config'
# /Users/jfrey/.gem/ruby/3.1.4/gems/activerecord-6.1.7.7/lib/active_record/connection_adapters/abstract/connection_pool.rb:1046:in `establish_connection'
# /Users/jfrey/.gem/ruby/3.1.4/gems/activerecord-6.1.7.7/lib/active_record/connection_handling.rb:52:in `establish_connection'
# ./spec/spec_helper.rb:98:in `<top (required)>'
# ------------------
# --- Caused by: ---
# Gem::LoadError:
#   can't activate sqlite3 (~> 1.4), already activated sqlite3-2.0.1-arm64-darwin. Make sure all dependencies are added to Gemfile.
#   /Users/jfrey/.gem/ruby/3.1.4/gems/activerecord-6.1.7.7/lib/active_record/connection_adapters/sqlite3_adapter.rb:13:in `<top (required)>'
Run options: include {:focus=>true}
```