### PR TITLE
Drop end of life rails < 7 and only support rubies 7 supports, 2.7+ (breaking change)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,24 +11,20 @@ jobs:
     strategy:
       matrix:
         ruby-version:
-        - '2.5'
-        - '2.6'
         - '2.7'
         - '3.0'
         - '3.1'
+        - '3.2'
+        - '3.3'
         rails-version:
-        - '6.0'
-        - '6.1'
-        include:
-        - ruby-version: '3.1'
-          rails-version: '6.1'
-        # rails 7 requires ruby 2.7+
+        - '7.0'
+        - '7.1'
+        - '7.2'
+        exclude:
         - ruby-version: '2.7'
-          rails-version: '7.0'
+          rails-version: '7.2'
         - ruby-version: '3.0'
-          rails-version: '7.0'
-        - ruby-version: '3.1'
-          rails-version: '7.0'
+          rails-version: '7.2'
     env:
       TEST_RAILS_VERSION: "${{ matrix.rails-version }}"
       CC_TEST_REPORTER_ID: "${{ secrets.CC_TEST_REPORTER_ID }}"

--- a/Gemfile
+++ b/Gemfile
@@ -4,14 +4,13 @@ gemspec
 
 minimum_version =
   case ENV['TEST_RAILS_VERSION']
-  when "6.0"
-    "~>6.0.4"
-  when "7.0"
-    "~>7.0.8"
+  when "7.2"
+    "~>7.2.1"
+  when "7.1"
+    "~>7.1.4"
   else
-    "~>6.1.4"
+    "~>7.0.8"
   end
-
 gem "activerecord", minimum_version
 
 # sqlite3 doesn't bundle properly with Rails 7.0 or less.

--- a/ovirt_metrics.gemspec
+++ b/ovirt_metrics.gemspec
@@ -19,9 +19,9 @@ Gem::Specification.new do |spec|
   spec.test_files   += %w[.rspec]
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.5.8"
+  spec.required_ruby_version = ">= 2.7"
 
-  spec.add_dependency "activerecord", ">=6.0"
+  spec.add_dependency "activerecord", ">=7.0"
   spec.add_dependency "pg"
 
   spec.add_development_dependency "bundler"


### PR DESCRIPTION
Drop ruby 2.5 and 2.6.
Drop rails 6.0 and 6.1.

Rails 7 is still supported and requires ruby 2.7 and higher so test with this minimal baseline.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
