### PR TITLE
Fix issues where active_support does not require logger properly

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -2,6 +2,6 @@
 
 require "bundler/setup"
 require "ovirt_metrics"
-require "pry"
 
-Pry.start
+require "irb"
+IRB.start

--- a/lib/ovirt_metrics.rb
+++ b/lib/ovirt_metrics.rb
@@ -1,3 +1,4 @@
+require "logger" # Require logger due to active_support breaking on Rails <= 7.0. See https://github.com/rails/rails/pull/54264
 require "active_record"
 require "ovirt_metrics/version"
 require "ovirt_metrics/configurator"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -97,6 +97,5 @@ OvirtMetrics.config do |c|
 end
 ActiveRecord::Base.establish_connection :adapter => "sqlite3", :database => ":memory:"
 
-require "active_record"
 puts
 puts "\e[93mUsing ActiveRecord #{ActiveRecord.version}\e[0m"

--- a/spec/support/active_record.rb
+++ b/spec/support/active_record.rb
@@ -1,3 +1,4 @@
+require "logger" # Require logger due to active_support breaking on Rails <= 7.0. See https://github.com/rails/rails/pull/54264
 require 'active_record'
 
 module ActiveModel::Validations


### PR DESCRIPTION
Require logger due to active_support breaking on Rails <= 7.0. See https://github.com/rails/rails/pull/54264

Also, Fix issue where pry is not in the gemspec/Gemfile (which was preventing testing bin/console)