### PR TITLE
Fix uninitialized constant PostgreSQLAdapter

### DIFF
--- a/lib/active_record/connection_adapters/ovirt_postgresql_adapter.rb
+++ b/lib/active_record/connection_adapters/ovirt_postgresql_adapter.rb
@@ -17,6 +17,8 @@ module ActiveRecord
   end
 
   module ConnectionAdapters
+    require 'active_record/connection_adapters/postgresql_adapter'
+
     class OvirtPostgreSQLAdapter < PostgreSQLAdapter
       ADAPTER_NAME = "OvirtPostgreSQL"
 


### PR DESCRIPTION
Unrelated to https://github.com/ManageIQ/ovirt_metrics/issues/65 but I hit this trying to reproduce that issue.
```
lib/active_record/connection_adapters/ovirt_postgresql_adapter.rb:20:in
`<module:ConnectionAdapters>': uninitialized constant ActiveRecord::ConnectionAdapters::PostgreSQLAdapter (NameError)

    class OvirtPostgreSQLAdapter < PostgreSQLAdapter
                                   ^^^^^^^^^^^^^^^^^
```

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
