### PR TITLE
Register ovirt postgresql on active record 7.2

### DIFF
--- a/lib/active_record/connection_adapters/ovirt_postgresql_adapter.rb
+++ b/lib/active_record/connection_adapters/ovirt_postgresql_adapter.rb
@@ -22,6 +22,14 @@ module ActiveRecord
     class OvirtPostgreSQLAdapter < PostgreSQLAdapter
       ADAPTER_NAME = "OvirtPostgreSQL"
 
+      # ActiveRecord 7.2 introduced a .register method for connection adapters,
+      # replacing the auto-require with path based on adapter name.
+      # Without registering the adapter active_record won't be able to find the
+      # ovirt_postgresql adapter.
+      if ActiveRecord::VERSION::MAJOR > 7 || (ActiveRecord::VERSION::MAJOR == 7 && ActiveRecord::VERSION::MINOR >= 2)
+        ActiveRecord::ConnectionAdapters.register('ovirt_postgresql', name, 'active_record/connection_adapters/ovirt_postgresql_adapter')
+      end
+
       def check_version
         msg = "The version of PostgreSQL (#{postgresql_version}) is too old (9.2+ required)"
         if postgresql_version < 90200


### PR DESCRIPTION
Use `ActiveRecord::ConnectionAdapters.register` to properly register the `OvirtPostgresqlAdapter` class on rails 7.2+

The interface for registering connection adapters changed in https://github.com/rails/rails/pull/50064

Depends on:
- [x] https://github.com/ManageIQ/ovirt_metrics/pull/66

Fixes https://github.com/ManageIQ/ovirt_metrics/issues/65
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
