### PR TITLE
Drop sqlite from development dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,3 @@ minimum_version =
     "~>7.0.8"
   end
 gem "activerecord", minimum_version
-
-# sqlite3 doesn't bundle properly with Rails 7.0 or less.
-gem "sqlite3", "< 2"

--- a/ovirt_metrics.gemspec
+++ b/ovirt_metrics.gemspec
@@ -29,5 +29,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec",         ">= 3.0"
   spec.add_development_dependency "simplecov",     ">= 0.21.2"
-  spec.add_development_dependency "sqlite3"
 end


### PR DESCRIPTION
After https://github.com/ManageIQ/ovirt_metrics/pull/69 we no longer need sqlite for development/test

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
